### PR TITLE
fix: default encoding for array params should be :multi

### DIFF
--- a/lib/crimson-falcon/configuration.rb
+++ b/lib/crimson-falcon/configuration.rb
@@ -122,7 +122,7 @@ module Falcon
       @cert_file = nil
       @key_file = nil
       @timeout = 0
-      @params_encoding = nil
+      @params_encoding = :multi
       @debugging = false
       @inject_format = false
       @force_ending_format = false


### PR DESCRIPTION
fixes #26

The default method that Typhoeus uses to encode our Array<String> params needed to be updated to match our API expected format.