### PR TITLE
fix: prevent recursion by using instance variable of hash

### DIFF
--- a/.openapi-generator/templates/partial_model_generic.mustache
+++ b/.openapi-generator/templates/partial_model_generic.mustache
@@ -364,7 +364,7 @@
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [{{#vars}}{{name}}{{^-last}}, {{/-last}}{{/vars}}].hash
+      [{{#vars}}{{#vendorExtensions.x-is-hash-attribute}}@{{name}}{{/vendorExtensions.x-is-hash-attribute}}{{^vendorExtensions.x-is-hash-attribute}}{{name}}{{/vendorExtensions.x-is-hash-attribute}}{{^-last}}, {{/-last}}{{/vars}}].hash
     end
 
 {{> base_object}}

--- a/.openapi-generator/transformation.jq
+++ b/.openapi-generator/transformation.jq
@@ -159,3 +159,12 @@
     end
   )
 
+  # Mark 'hash' property to avoid recursion in hash method
+  | walk(
+      if type == "object" and has("properties") and (.properties | has("hash")) then
+        .properties.hash["x-is-hash-attribute"] = true
+      else
+        .
+      end
+    )
+

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ We appreciate your interest in our project and look forward to collaborating wit
 
 - **Operation**: [**service_now_get_deployments**](docs/ASPM.md#service_now_get_deployments)
 - **GET**: /aspm-api-gateway/api/v1/servicenow/deployments
-- **Description**:
+- **Description**: 
 
 ---
 
@@ -271,7 +271,7 @@ We appreciate your interest in our project and look forward to collaborating wit
 
 - **Operation**: [**service_now_get_services**](docs/ASPM.md#service_now_get_services)
 - **GET**: /aspm-api-gateway/api/v1/servicenow/services
-- **Description**:
+- **Description**: 
 
 ---
 
@@ -335,7 +335,7 @@ We appreciate your interest in our project and look forward to collaborating wit
 
 - **Operation**: [**patch_entities_alerts_v2**](docs/Alerts.md#patch_entities_alerts_v2)
 - **PATCH**: /alerts/entities/alerts/v2
-- **Description**: Deprecated: Please use version v3 of this endpoint. Perform actions on Alerts identified by composite ID(s) in request. Each action has a name and a description which describes what the action does. If a request adds and removes tag in a single request, the order of processing would be to remove tags before adding new ones in.
+- **Description**: Deprecated: Please use version v3 of this endpoint. Perform actions on Alerts identified by composite ID(s) in request. Each action has a name and a description which describes what the action does. If a request adds and removes tag in a single request, the order of processing would be to remove tags before adding new ones in.  
 
 ---
 
@@ -343,7 +343,7 @@ We appreciate your interest in our project and look forward to collaborating wit
 
 - **Operation**: [**patch_entities_alerts_v3**](docs/Alerts.md#patch_entities_alerts_v3)
 - **PATCH**: /alerts/entities/alerts/v3
-- **Description**: Perform actions on Alerts identified by composite ID(s) in request. Each action has a name and a description which describes what the action does. If a request adds and removes tag in a single request, the order of processing would be to remove tags before adding new ones in.
+- **Description**: Perform actions on Alerts identified by composite ID(s) in request. Each action has a name and a description which describes what the action does. If a request adds and removes tag in a single request, the order of processing would be to remove tags before adding new ones in.  
 
 ---
 
@@ -1935,7 +1935,7 @@ We appreciate your interest in our project and look forward to collaborating wit
 
 - **Operation**: [**get_data_scanner_tasks**](docs/Datascanner.md#get_data_scanner_tasks)
 - **GET**: /data-security-dspm/entities/scanner-tasks/v1
-- **Description**:
+- **Description**: 
 
 ---
 
@@ -1943,7 +1943,7 @@ We appreciate your interest in our project and look forward to collaborating wit
 
 - **Operation**: [**get_image_registry_credentials**](docs/Datascanner.md#get_image_registry_credentials)
 - **GET**: /data-security-dspm/entities/image-registry-credentials/v1
-- **Description**:
+- **Description**: 
 
 ---
 
@@ -1951,7 +1951,7 @@ We appreciate your interest in our project and look forward to collaborating wit
 
 - **Operation**: [**update_data_scanner_tasks**](docs/Datascanner.md#update_data_scanner_tasks)
 - **PATCH**: /data-security-dspm/entities/scanner-tasks/v1
-- **Description**:
+- **Description**: 
 
 ---
 
@@ -2839,7 +2839,7 @@ We appreciate your interest in our project and look forward to collaborating wit
 
 - **Operation**: [**delete_rule_groups**](docs/Filevantage.md#delete_rule_groups)
 - **DELETE**: /filevantage/entities/rule-groups/v1
-- **Description**: Deletes 1 or more rule groups
+- **Description**: Deletes 1 or more rule groups 
 
 ---
 
@@ -3503,7 +3503,7 @@ We appreciate your interest in our project and look forward to collaborating wit
 
 - **Operation**: [**handle**](docs/Handle.md#handle)
 - **POST**: /data-security-dspm/entities/kafka-rest-produce/v1
-- **Description**:
+- **Description**: 
 
 ---
 
@@ -5199,7 +5199,7 @@ We appreciate your interest in our project and look forward to collaborating wit
 
 - **Operation**: [**add_role**](docs/Mssp.md#add_role)
 - **POST**: /mssp/entities/mssp-roles/v1
-- **Description**: Create a link between user group and CID group, with zero or more additional roles. The call does not replace any existing link between them. User group ID and CID group ID have to be specified in request.
+- **Description**: Create a link between user group and CID group, with zero or more additional roles. The call does not replace any existing link between them. User group ID and CID group ID have to be specified in request. 
 
 ---
 
@@ -6239,7 +6239,7 @@ We appreciate your interest in our project and look forward to collaborating wit
 
 - **Operation**: [**get_notifications_detailed_translated_v1**](docs/Recon.md#get_notifications_detailed_translated_v1)
 - **GET**: /recon/entities/notifications-detailed-translated/v1
-- **Description**: Get detailed notifications based on their IDs. These include the translated raw intelligence content that generated the match or part of it.
+- **Description**: Get detailed notifications based on their IDs. These include the translated raw intelligence content that generated the match or part of it. 
 
 ---
 
@@ -6247,7 +6247,7 @@ We appreciate your interest in our project and look forward to collaborating wit
 
 - **Operation**: [**get_notifications_detailed_v1**](docs/Recon.md#get_notifications_detailed_v1)
 - **GET**: /recon/entities/notifications-detailed/v1
-- **Description**: Get detailed notifications based on their IDs. These include the raw intelligence content that generated the match or part of it.
+- **Description**: Get detailed notifications based on their IDs. These include the raw intelligence content that generated the match or part of it. 
 
 ---
 
@@ -7346,6 +7346,7 @@ We appreciate your interest in our project and look forward to collaborating wit
 - **Description**: Get the Zero Trust Assessment audit report for one customer ID (CID).
 
 ---
+
 
 ## Support
 

--- a/lib/crimson-falcon/models/domain_malicious_file.rb
+++ b/lib/crimson-falcon/models/domain_malicious_file.rb
@@ -213,7 +213,7 @@ module Falcon
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [cid, filename, filepath, hash, host_id, host_scan_id, id, last_updated, pattern_id, quarantined, scan_id, severity].hash
+      [cid, filename, filepath, @hash, host_id, host_scan_id, id, last_updated, pattern_id, quarantined, scan_id, severity].hash
     end
 
     # Builds the object from hash

--- a/lib/crimson-falcon/models/models_detection.rb
+++ b/lib/crimson-falcon/models/models_detection.rb
@@ -240,7 +240,7 @@ module Falcon
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [description, details, hash, id, name, path, remediation, severity, title, type].hash
+      [description, details, @hash, id, name, path, remediation, severity, title, type].hash
     end
 
     # Builds the object from hash

--- a/lib/crimson-falcon/models/models_elf_binary.rb
+++ b/lib/crimson-falcon/models/models_elf_binary.rb
@@ -156,7 +156,7 @@ module Falcon
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [hash, path, permissions, size].hash
+      [@hash, path, permissions, size].hash
     end
 
     # Builds the object from hash

--- a/lib/crimson-falcon/models/resources_cloud_resource.rb
+++ b/lib/crimson-falcon/models/resources_cloud_resource.rb
@@ -479,7 +479,7 @@ module Falcon
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [account_id, account_name, active, arn, category, cid, cloud_context, cloud_groups, cloud_labels, cloud_provider, cluster_id, cluster_name, configuration, creation_time, first_seen, hash, id, location, organization_id, parent, project_id, project_number, region, relationships, resource_group, resource_id, resource_name, resource_number, resource_type, resource_type_name, resource_url, revision, service, status, subscription_id, supplementary_configuration, tags, tenant_id, updated_at, zone, zones].hash
+      [account_id, account_name, active, arn, category, cid, cloud_context, cloud_groups, cloud_labels, cloud_provider, cluster_id, cluster_name, configuration, creation_time, first_seen, @hash, id, location, organization_id, parent, project_id, project_number, region, relationships, resource_group, resource_id, resource_name, resource_number, resource_type, resource_type_name, resource_url, revision, service, status, subscription_id, supplementary_configuration, tags, tenant_id, updated_at, zone, zones].hash
     end
 
     # Builds the object from hash

--- a/lib/crimson-falcon/models/types_artifact.rb
+++ b/lib/crimson-falcon/models/types_artifact.rb
@@ -136,7 +136,7 @@ module Falcon
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [full_path, hash, id, name].hash
+      [full_path, @hash, id, name].hash
     end
 
     # Builds the object from hash


### PR DESCRIPTION
fixes #47

There was an issue where if the generated hash function of values contained a value == 'hash', then it would essentially recursively call itself.