### PR TITLE
ci: harden GitHub Actions workflows for security

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,27 +3,29 @@ name: Build
 on:
   push:
     branches: [main]
-  pull_request_target:
-    types: [labeled]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   build:
     name: Build and Install Gem
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request_target' &&
-      github.event.label.name == 'ok-to-test')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 15
     strategy:
       matrix:
         ruby-version: ["3.0", "3.1", "3.2"]
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
@@ -35,8 +37,4 @@ jobs:
         run: make install
 
       - name: Run tests
-        env:
-          FALCON_CLIENT_ID: ${{ secrets.FALCON_CLIENT_ID }}
-          FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
-          FALCON_CLOUD: ${{ secrets.FALCON_CLOUD }}
         run: bundle exec rspec

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,19 +2,20 @@ name: "CodeQL"
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches:
-      - main
+    branches: [main]
   schedule:
     - cron: '43 0 * * 6'
+
+permissions:
+  contents: read
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read
@@ -23,41 +24,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'ruby' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+        language: ['ruby']
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
+      uses: github/codeql-action/autobuild@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,25 +2,29 @@ name: RuboCop Linter
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   rubocop:
     name: RuboCop
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1
       with:
         ruby-version: 3.2
-
-    - name: Install dependencies
-      run: bundle install
+        bundler-cache: true
 
     - name: Run RuboCop
       run: rubocop

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,54 +1,60 @@
 name: release-please
 on:
   push:
-    branches:
-      - main
+    branches: [main]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      release_created: ${{ steps.release-please.outputs.release_created }}
+      tag_name: ${{ steps.release-please.outputs.tag_name }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@db8f2c60ee802b3748b512940dde88eabd7b7e01 # v3.7.13
         id: release-please
         with:
           release-type: ruby
           package-name: crimson-falcon
           version-file: "lib/crimson-falcon/version.rb"
           pull-request-header: ':rocket: Prepare for Launch: New Release Incoming!'
-          # Override the changelog section to include miscellaneous changes.
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'
           extra-files: |
             .openapi-generator/config.yml
             README.md
-      # The following steps are only executed if a release is created.
-      - name: Check out code
-        uses: actions/checkout@v4
-        if: ${{ steps.release-please.outputs.release_created }}
+
+  gem-publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
 
       - name: Set up Ruby 3.2
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@3ff19f5e2baf30647122352b96108b1fbe250c64 # v1
         with:
           ruby-version: 3.2
-        if: ${{ steps.release-please.outputs.release_created }}
+          bundler-cache: true
 
-      - name: Install dependencies
-        run: bundle install
-        if: ${{ steps.release-please.outputs.release_created }}
+      - name: Build and verify gem
+        run: |
+          make build
+          make install
 
-      - name: Build gem
-        run: make build
-        if: ${{ steps.release-please.outputs.release_created }}
-
-      - name: Ensure gem installs
-        run: make install
-        if: ${{ steps.release-please.outputs.release_created }}
-
-      - name: Publish gem
-        run: gem push crimson-falcon-*.gem
-        env:
-          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-        if: ${{ steps.release-please.outputs.release_created }}
+      - name: Publish to RubyGems
+        uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0


### PR DESCRIPTION
Hardens all four GitHub Actions workflows with security best practices:

**release.yml** — Split into two jobs: `release-please` (creates releases) and `gem-publish` (publishes the gem). The publish job now uses OIDC trusted publishing via `rubygems/release-gem` instead of the long-lived `RUBYGEMS_API_KEY` secret, and is gated behind `environment: release` so it only runs when a release is actually created. Release-please is pinned to the same SHA used by falcon-mcp (`db8f2c60...`, v3.7.13).

**build.yml** — Replaced `pull_request_target` with `pull_request`, removing the `ok-to-test` label gate and all `FALCON_*` secret references from the test step. This eliminates the fork-code-execution-with-secrets attack surface.

**codeql-analysis.yml** — Upgraded CodeQL actions from v2 (deprecated) to v3.

**All workflows** — Pinned every action to full commit SHAs, added `permissions: contents: read` at the top level with per-job scoping, and added `timeout-minutes` to all jobs.

### Setup required after merge
- Configure the `release` environment in GitHub repo settings with required reviewers and branch protection
- Configure trusted publishing on rubygems.org for the `crimson-falcon` gem (link to this repo's `release.yml` workflow and `release` environment)