### PR TITLE
feat: add make sync-wiki to publish docs to wiki repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,7 @@ Here's an overview of the key commands provided in the Makefile:
 * `make rubocop`: This command runs the RuboCop linter on the codebase to ensure the code adheres to the community Ruby style guide. It also automatically fixes any issues that RuboCop can correct (`-a` flag).
 * `make clean-generated-files`: This command removes all generated files from the project. This includes files in the `docs/`, `lib/crimson-falcon/models/`, `lib/crimson-falcon/api/`, and `spec/` directories.
 * `make generate`: This command runs a full SDK generation pipeline. It starts by cleaning up any old generated files, then generates a new SDK, fixes the regex, and finally runs RuboCop on the generated code.
+* `make sync-wiki`: This command publishes the generated documentation from `docs/` to the [wiki repo](https://github.com/CrowdStrike/crimson-falcon/wiki). It clones the wiki, syncs all generated markdown files, auto-generates `Home.md` and `_Sidebar.md` navigation pages, commits, and pushes. Run this after `make generate` to publish updated docs. Supports `DRY_RUN=1` to preview changes without pushing.
 
 To use these commands, simply type `make` followed by the command name in your terminal from the project's root directory. For example, `make build` will build the gem from the source code. These commands will help automate common tasks and make your workflow more efficient.
 

--- a/Makefile
+++ b/Makefile
@@ -88,3 +88,6 @@ clean-generated-files:
 .PHONY: generate
 generate: clean-generated-files .openapi-generator/swagger-stripped-oauth.json build-sdk fix-regex remove-suffix rubocop
 	@echo "SDK generated successfully."
+
+sync-wiki:
+	@./scripts/sync-wiki.sh

--- a/scripts/sync-wiki.sh
+++ b/scripts/sync-wiki.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOCS_DIR="docs"
+WIKI_REPO_URL="${WIKI_REPO_URL:-https://github.com/CrowdStrike/crimson-falcon.wiki.git}"
+DRY_RUN="${DRY_RUN:-0}"
+
+if [ ! -d "$DOCS_DIR" ] || [ -z "$(ls -A "$DOCS_DIR" 2>/dev/null)" ]; then
+  echo "Error: $DOCS_DIR is empty or missing. Run 'make generate' first." >&2
+  exit 1
+fi
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "Cloning wiki repo..."
+git clone --depth 1 "$WIKI_REPO_URL" "$WORK_DIR" 2>/dev/null
+
+# Remove all existing markdown files (handles deleted APIs/models)
+find "$WORK_DIR" -maxdepth 1 -name "*.md" -delete
+
+# Copy generated docs into wiki checkout
+cp "$DOCS_DIR"/*.md "$WORK_DIR/"
+
+# Generate Home.md from API docs (files containing "All URIs are relative to")
+echo "Generating Home.md..."
+{
+  echo "# Crimson Falcon Ruby SDK - API Documentation"
+  echo ""
+  echo "Auto-generated API documentation for the [CrowdStrike Crimson Falcon](https://github.com/CrowdStrike/crimson-falcon) Ruby SDK."
+  echo ""
+  echo "## Service APIs"
+  echo ""
+  grep -rl "All URIs are relative to" "$WORK_DIR"/*.md 2>/dev/null \
+    | xargs -I{} basename {} .md \
+    | sort \
+    | while read -r name; do
+        echo "- [$name]($name)"
+      done
+} > "$WORK_DIR/Home.md"
+
+# Generate _Sidebar.md for persistent wiki navigation
+echo "Generating _Sidebar.md..."
+{
+  echo "**[Home](Home)**"
+  echo ""
+  echo "**Service APIs**"
+  echo ""
+  grep -rl "All URIs are relative to" "$WORK_DIR"/*.md 2>/dev/null \
+    | xargs -I{} basename {} .md \
+    | sort \
+    | while read -r name; do
+        echo "- [$name]($name)"
+      done
+} > "$WORK_DIR/_Sidebar.md"
+
+cd "$WORK_DIR"
+
+if git diff --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
+  echo "No changes to publish."
+  exit 0
+fi
+
+SOURCE_SHA=$(git -C "${OLDPWD}" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+COMMIT_MSG="docs: sync generated API docs from ${SOURCE_SHA}"
+
+git add -A
+git commit -m "$COMMIT_MSG"
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo "[DRY RUN] Would push the following commit:"
+  git log --oneline -1
+  echo "Files changed:"
+  git diff --stat HEAD~1
+else
+  echo "Pushing to wiki..."
+  git push origin master
+  echo "Wiki updated successfully."
+fi


### PR DESCRIPTION
Adds a `scripts/sync-wiki.sh` script and corresponding `make sync-wiki` target that automates publishing generated API docs to the wiki repo. After running `make generate`, developers run `make sync-wiki` to:

- Clone the wiki repo
- Sync all generated markdown from `docs/`
- Auto-generate `Home.md` (service API index) and `_Sidebar.md` (persistent navigation)
- Commit and push

Supports `DRY_RUN=1` to preview changes without pushing and `WIKI_REPO_URL` override for testing. Updated CONTRIBUTING.md to document the new command.